### PR TITLE
Weapons from GS to KPCF

### DIFF
--- a/cmf211_CCE_Desert_Scorpion_V1.tem_kujari/KPCF_config.sqf
+++ b/cmf211_CCE_Desert_Scorpion_V1.tem_kujari/KPCF_config.sqf
@@ -56,11 +56,11 @@ KPCF_whitelistedItems = [
 // Defines the available weapons
 KPCF_weapons = [
     //Germany
-    "LIB_MG34","LIB_K98_Late","LIB_MP40","LIB_P08"
+    "fow_w_mg42","CSA38_kar98k","fow_w_mp40","LIB_P08","fow_w_g43","fow_w_pzfaust_60"
     ,"LIB_RPzB"
-    //AMERIKEE
-    ,"LIB_M1_Garand","LIB_M1918A2_BAR","LIB_M1928A1_Thompson","LIB_Colt_M1911"
-    ,"LIB_M1A1_Bazooka"
+    //UK
+    ,"CSA38_No4","CSA38_BRENMKII","CSA38_stenMkIII","LIB_Webley_mk6","LIB_LeeEnfield_No4_CUP","CSA38_stenMkVI"
+    ,"LIB_PIAT"
     //Uni 
     ,"LIB_FLARE_PISTOL"
 ];


### PR DESCRIPTION
Added the weapons from the gearscripts into KPCF. 

Might tinker with this some more to see if the blacklist works so there arent loads of different ammo types. Not that I actually think that will present any issues, but if its possible its nice to be safe. Will only tinker with that after you push this PR through so as not to accident anything into main branch.